### PR TITLE
Update translit_language_pack.py

### DIFF
--- a/src/transliterate/contrib/languages/ka/translit_language_pack.py
+++ b/src/transliterate/contrib/languages/ka/translit_language_pack.py
@@ -17,7 +17,7 @@ class GeorgianLanguagePack(TranslitLanguagePack):
     """
     language_code = "ka"
     language_name = "Georgian"
-    character_ranges = ((0x10A0, 0x10C5), (0x10D0, 0x10FC), (0x2D00, 0x2D25))
+    character_ranges = ((0x10D0, 0x10F0))
     mapping = data.mapping
     pre_processor_mapping = data.pre_processor_mapping
     detectable = True


### PR DESCRIPTION
I removed character ranges in "character_ranges" because other two character ranges, which I removed, is not used anymore. In other words, characters in this ranges are very old and is taken out from modern alphabet.